### PR TITLE
Use centos:8 in Dockerfile.tools

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM centos:8
 
 ENV HOME=/home/ci
 ENV GOROOT /usr/local/go


### PR DESCRIPTION
The CI started failing with the following message:

STEP 7: RUN initializer --manifests /registry/performance-addon-operator-catalog --output bundles.db
initializer: /lib64/libc.so.6: version `GLIBC_2.28' not found (required by initializer)

That is caused by too old glibc. Lets see if newer release of the base image will solve it.